### PR TITLE
Support building on Darwin and Docker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '40 3 * * *'
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '40 3 * * *'
+  push:
+    branches: [ "main" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM docker.io/rust:1.77 AS build
 RUN apt-get update; apt-get upgrade -y 
 RUN apt-get install -y clang llvm-dev
-RUN wget https://ftp.postgresql.org/pub/source/v15.6/postgresql-15.6.tar.gz
-RUN tar xzf postgresql-15.6.tar.gz
-RUN cd postgresql-15.6; ./configure --prefix=/usr/local; make -j$(nproc); make install
+RUN wget https://ftp.postgresql.org/pub/source/v16.6/postgresql-16.6.tar.gz
+RUN tar xzf postgresql-16.6.tar.gz
+RUN cd postgresql-16.6; ./configure --prefix=/usr/local; make -j$(nproc); make install
 RUN mkdir /work
 COPY Cargo.toml Cargo.lock install.sh README.md build.rs wrapper.h /work/
 COPY src/ /work/src/
@@ -13,9 +13,9 @@ COPY sql/ /work/sql
 WORKDIR /work
 RUN cargo build --release
 
-FROM docker.io/postgres:15.6
-COPY --from=build /work/target/release/libchamkho_parser.so /usr/lib/postgresql/15/lib/chamkho_parser.so
-COPY --from=build /work/control/*.control /work/sql/*.sql /usr/share/postgresql/15/extension/
+FROM docker.io/postgres:16.6
+COPY --from=build /work/target/release/libchamkho_parser.so /usr/lib/postgresql/16/lib/chamkho_parser.so
+COPY --from=build /work/control/*.control /work/sql/*.sql /usr/share/postgresql/16/extension/
 COPY --from=build /work /work
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN wget https://ftp.postgresql.org/pub/source/v15.6/postgresql-15.6.tar.gz
 RUN tar xzf postgresql-15.6.tar.gz
 RUN cd postgresql-15.6; ./configure --prefix=/usr/local; make -j$(nproc); make install
 RUN mkdir /work
-COPY Cargo.toml Cargo.lock install.sh README.md build.rs wrapper.h .cargo /work/
+COPY Cargo.toml Cargo.lock install.sh README.md build.rs wrapper.h /work/
 COPY src/ /work/src/
 COPY control/ /work/control/
 COPY data/ /work/data/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ to_tsvector
 
 ## Status
 
-chamkho-pg currently support PostgreSQL 15 on GNU/Linux.
+chamkho-pg currently supports PostgreSQL 15 and 16 on both GNU/Linux and macOS.
+
+Current Docker images are built with PostgreSQL 16.6.
 
 ## Example
 

--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,13 @@ fn main() {
 
     // Add macOS-specific include path for gettext if on macOS
     if cfg!(target_os = "macos") {
-        builder = builder.clang_arg("-I/opt/homebrew/opt/gettext/include");
+        let gettext_include = Command::new("brew")
+            .args(["--prefix", "gettext"])
+            .output()
+            .expect("Failed to get gettext path from brew")
+            .stdout;
+        let gettext_include = format!("-I{}/include", String::from_utf8_lossy(&gettext_include).trim_end());
+        builder = builder.clang_arg(&gettext_include);
     }
 
     let bindings = builder

--- a/build.rs
+++ b/build.rs
@@ -19,30 +19,40 @@ fn main() {
     let lib_dir = lib_dir.trim_end();
     let include_flag = format!("-I{}", String::from_utf8_lossy(&include_dir_out.stdout).trim_end());
 
-    // Add explicit gettext paths
-    let gettext_include = "/opt/homebrew/opt/gettext/include";
-    let gettext_lib = "/opt/homebrew/opt/gettext/lib";
-
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-link-search={}", pkg_lib_dir);
     println!("cargo:rustc-link-search={}", lib_dir);
-    println!("cargo:rustc-link-search={}", gettext_lib);
     println!("cargo::rustc-link-arg=-fPIC");
-    
-    // Add link to intl library
-    println!("cargo:rustc-link-lib=intl");
 
-    // Add link to PostgreSQL libraries
-    println!("cargo:rustc-link-lib=pq");
-    println!("cargo:rustc-link-lib=pgcommon");
-    println!("cargo:rustc-link-lib=pgport");
+    if cfg!(target_os = "macos") {
+        // Get gettext lib path from brew
+        let gettext_lib = Command::new("brew")
+            .args(["--prefix", "gettext"])
+            .output()
+            .expect("Failed to get gettext path from brew")
+            .stdout;
+        let gettext_lib = format!("{}/lib", String::from_utf8_lossy(&gettext_lib).trim_end());
+        println!("cargo:rustc-link-search={}", gettext_lib);
+        println!("cargo:rustc-link-lib=intl");
 
-    let bindings = bindgen::Builder::default()
+        // Add link to PostgreSQL libraries
+        println!("cargo:rustc-link-lib=pq");
+        println!("cargo:rustc-link-lib=pgcommon");
+        println!("cargo:rustc-link-lib=pgport");
+    }
+
+    let mut builder = bindgen::Builder::default()
         .header("wrapper.h")
-        .clang_arg(&include_flag)
-        .clang_arg("-fPIC")
-        .clang_arg(format!("-I{}", gettext_include))
+        .clang_arg(include_flag)
+        .clang_arg("-fPIC");
+
+    // Add macOS-specific include path for gettext if on macOS
+    if cfg!(target_os = "macos") {
+        builder = builder.clang_arg("-I/opt/homebrew/opt/gettext/include");
+    }
+
+    let bindings = builder
         .blocklist_item("FP_NAN")
         .blocklist_item("FP_INFINITE")
         .blocklist_item("FP_ZERO")

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
+
 fn main() {
     let pkg_lib_dir_out = Command::new("pg_config")
         .arg("--pkglibdir")
@@ -11,22 +12,37 @@ fn main() {
         .arg("--includedir-server")
         .output()
         .unwrap();
+
     let pkg_lib_dir = String::from_utf8_lossy(&pkg_lib_dir_out.stdout);
     let pkg_lib_dir = pkg_lib_dir.trim_end();
     let lib_dir = String::from_utf8_lossy(&lib_dir_out.stdout);
     let lib_dir = lib_dir.trim_end();
-    let include_flag = format!("-I{}", String::from_utf8_lossy(&include_dir_out.stdout));
-    let include_flag = include_flag.trim_end();
-    //    println!("cargo:rustc-link-lib=pgcommon");
+    let include_flag = format!("-I{}", String::from_utf8_lossy(&include_dir_out.stdout).trim_end());
+
+    // Add explicit gettext paths
+    let gettext_include = "/opt/homebrew/opt/gettext/include";
+    let gettext_lib = "/opt/homebrew/opt/gettext/lib";
+
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-link-search={}", pkg_lib_dir);
     println!("cargo:rustc-link-search={}", lib_dir);
+    println!("cargo:rustc-link-search={}", gettext_lib);
     println!("cargo::rustc-link-arg=-fPIC");
+    
+    // Add link to intl library
+    println!("cargo:rustc-link-lib=intl");
+
+    // Add link to PostgreSQL libraries
+    println!("cargo:rustc-link-lib=pq");
+    println!("cargo:rustc-link-lib=pgcommon");
+    println!("cargo:rustc-link-lib=pgport");
+
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
-        .clang_arg(include_flag)
+        .clang_arg(&include_flag)
         .clang_arg("-fPIC")
+        .clang_arg(format!("-I{}", gettext_include))
         .blocklist_item("FP_NAN")
         .blocklist_item("FP_INFINITE")
         .blocklist_item("FP_ZERO")
@@ -34,6 +50,7 @@ fn main() {
         .blocklist_item("FP_SUBNORMAL")
         .generate()
         .expect("Unable to generate bindings");
+
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))

--- a/config.toml
+++ b/config.toml
@@ -3,3 +3,9 @@ rustflags = "-C link-arg=-undefineddynamic_lookup"
 
 [target.'cfg(windows)']
 rustflags = "-C link-arg=/FORCE"
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup"
+]

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,13 @@
 #!/bin/sh
 
-# Determine the platform-specific library extension
-if [ "$(uname)" = "Darwin" ]; then
-    LIB_EXT="dylib"
-else
-    LIB_EXT="so"
-fi
-
 # Copy the library with the correct extension
-cp "target/release/libchamkho_parser.$LIB_EXT" "$(pg_config --libdir)/postgresql/chamkho_parser.so"
+if [ "$(uname)" = "Darwin" ]; then
+    # Depending on the brew formula version, the expected extension can be either .dylib or .so
+    cp "target/release/libchamkho_parser.dylib" "$(pg_config --libdir)/postgresql/chamkho_parser.dylib"
+    ln -sf "$(pg_config --libdir)/postgresql/chamkho_parser.dylib" "$(pg_config --libdir)/postgresql/chamkho_parser.so"
+else
+    cp "target/release/libchamkho_parser.so" "$(pg_config --libdir)/postgresql/chamkho_parser.so"
+fi
 
 # Copy extension files
 cp control/*.control sql/*.sql "$(pg_config --sharedir)/extension"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cp target/release/libchamkho_parser.so `pg_config --libdir`/postgresql/chamkho_parser.so
+cp target/release/libchamkho_parser.dylib `pg_config --libdir`/postgresql/chamkho_parser.so
 cp control/*.control sql/*.sql `pg_config --sharedir`/extension

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
 
-cp target/release/libchamkho_parser.dylib `pg_config --libdir`/postgresql/chamkho_parser.so
-cp control/*.control sql/*.sql `pg_config --sharedir`/extension
+# Determine the platform-specific library extension
+if [ "$(uname)" = "Darwin" ]; then
+    LIB_EXT="dylib"
+else
+    LIB_EXT="so"
+fi
+
+# Copy the library with the correct extension
+cp "target/release/libchamkho_parser.$LIB_EXT" "$(pg_config --libdir)/postgresql/chamkho_parser.so"
+
+# Copy extension files
+cp control/*.control sql/*.sql "$(pg_config --sharedir)/extension"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,8 +143,8 @@ pub(crate) unsafe fn guard_pg<R, F: FnOnce() -> R>(f: F) -> R {
     let original_exception_stack: *mut sys::sigjmp_buf = sys::PG_exception_stack;
     let mut local_exception_stack: std::mem::MaybeUninit<sys::sigjmp_buf> =
         std::mem::MaybeUninit::uninit();
-    let jumped = sys::__sigsetjmp(
-        // grab a mutable reference, cast to a mutabl pointr, then case to the expected erased pointer type
+    let jumped = sys::sigsetjmp(
+        // grab a mutable reference, cast to a mutable pointer, then case to the expected erased pointer type
         local_exception_stack.as_mut_ptr() as *mut sys::sigjmp_buf as *mut _,
         1,
     );


### PR DESCRIPTION
### Darwin

Added support for building on macOS, linking against headers from homebrew and handling a bunch of tiny variations between the platforms.

### GNU/Linux

No changes made except a remark to confirm that the existing code also works with Postgres 16.

### Docker

Added a GitHub Action to build Docker images automatically. Updated Dockerfile to build against Postgres 16.6.